### PR TITLE
Feature allow to set host of backend in url

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -17,6 +17,15 @@ if (backend_id) {
   if (backend.backend_ids.includes(backend_id)) {
     console.log(`Switching to the "${backend_id}" backend.`);
     backend.backend_id = backend_id;
+
+    if (route.query.host) {
+      let host = route.query.host;
+      if (!host.startsWith("http")) {
+        host = "https://" + host;
+      }
+      console.log("host", host);
+      backend.current.base_url = host;
+    }
   } else {
     valid_backend_id = false;
   }


### PR DESCRIPTION
You can now force the `api_url` to change using the `host` url parameter:

```
https://diffusionui.com/b/automatic1111?host=12345.gradio.app
```