### PR TITLE
Feature reload backend config if diffusion-ui version changed

### DIFF
--- a/src/version.js
+++ b/src/version.js
@@ -1,0 +1,3 @@
+const version = 0.1;
+
+export { version };


### PR DESCRIPTION
To avoid problems with people having old configs from previous versions.